### PR TITLE
Enable ONNX export

### DIFF
--- a/lib/models/cls_hrnet.py
+++ b/lib/models/cls_hrnet.py
@@ -474,9 +474,12 @@ class HighResolutionNet(nn.Module):
 
         y = self.final_layer(y)
 
-        y = F.avg_pool2d(y, kernel_size=y.size()
-                             [2:]).view(y.size(0), -1)
-            
+        if torch._C._get_tracing_state():
+            y = y.flatten(start_dim=2).mean(dim=2)
+        else:
+            y = F.avg_pool2d(y, kernel_size=y.size()
+                                 [2:]).view(y.size(0), -1)
+
         y = self.classifier(y)
 
         return y


### PR DESCRIPTION
Related issue in PyTorch https://github.com/pytorch/pytorch/issues/23474#issuecomment-522748992

This PR is for enalbing ONNX export for this model. ONNX does not support average pool with dynamic kernel size. Since the kernel size in this case is always the same as input spatial size, the average pool operator can be replaced with `mean`.

Here I used the flag `torch._C._get_tracing_state():`, such that the change only takes effect when users are exporting the model to ONNX. No changes to normal usages such as model training/validating. 